### PR TITLE
Add FastAPI portfolio service with role-based API and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.db
+__pycache__/
+/.pytest_cache/
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Aegis-IMX
-Aegis-IMX
+
+## Portfolio Service
+
+This project provides a minimal FastAPI implementation of a portfolio service.
+It supports portfolio CRUD operations with role-based access control and basic
+position aggregation.
+
+### Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+### Running Tests
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.109.2
+uvicorn==0.27.1
+sqlalchemy==2.0.29
+pydantic==2.7.4
+pytest==8.1.1
+httpx==0.27.0

--- a/src/portfolio_service/db.py
+++ b/src/portfolio_service/db.py
@@ -1,0 +1,21 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = "sqlite:///./portfolio.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+Base = declarative_base()
+
+
+def get_db():
+    """Yield a database session for request scope."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/portfolio_service/main.py
+++ b/src/portfolio_service/main.py
@@ -1,0 +1,124 @@
+import logging
+from typing import List, Sequence
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .db import Base, engine, get_db
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Portfolio Service")
+
+ALLOWED_ROLES = {"PM", "Risk", "Ops", "Compliance", "Client"}
+
+
+def get_role(x_role: str = Header(...)) -> str:
+    """Validate and return the caller's role from headers."""
+    if x_role not in ALLOWED_ROLES:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid role")
+    return x_role
+
+
+def require_roles(roles: Sequence[str]):
+    """Dependency factory enforcing role-based access."""
+
+    def checker(role: str = Depends(get_role)) -> str:
+        if role not in roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Access forbidden"
+            )
+        return role
+
+    return checker
+
+
+@app.post(
+    "/portfolios",
+    response_model=schemas.PortfolioRead,
+    dependencies=[Depends(require_roles({"PM", "Ops", "Compliance"}))],
+)
+def create_portfolio(
+    portfolio: schemas.PortfolioCreate, db: Session = Depends(get_db)
+):
+    """Create a new portfolio with optional positions."""
+    logger.info("Creating portfolio %s", portfolio.name)
+    db_portfolio = models.Portfolio(name=portfolio.name)
+    for pos in portfolio.positions:
+        db_portfolio.positions.append(
+            models.Position(
+                instrument=pos.instrument, quantity=pos.quantity, sector=pos.sector
+            )
+        )
+    db.add(db_portfolio)
+    db.commit()
+    db.refresh(db_portfolio)
+    return db_portfolio
+
+
+@app.get(
+    "/portfolios/{portfolio_id}",
+    response_model=schemas.PortfolioRead,
+    dependencies=[Depends(require_roles(ALLOWED_ROLES))],
+)
+def read_portfolio(portfolio_id: int, db: Session = Depends(get_db)):
+    portfolio = db.get(models.Portfolio, portfolio_id)
+    if not portfolio:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return portfolio
+
+
+@app.put(
+    "/portfolios/{portfolio_id}",
+    response_model=schemas.PortfolioRead,
+    dependencies=[Depends(require_roles({"PM", "Ops", "Compliance"}))],
+)
+def update_portfolio(
+    portfolio_id: int, data: schemas.PortfolioBase, db: Session = Depends(get_db)
+):
+    portfolio = db.get(models.Portfolio, portfolio_id)
+    if not portfolio:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    portfolio.name = data.name
+    db.commit()
+    db.refresh(portfolio)
+    return portfolio
+
+
+@app.delete(
+    "/portfolios/{portfolio_id}",
+    dependencies=[Depends(require_roles({"Ops"}))],
+)
+def delete_portfolio(portfolio_id: int, db: Session = Depends(get_db)):
+    portfolio = db.get(models.Portfolio, portfolio_id)
+    if not portfolio:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    db.delete(portfolio)
+    db.commit()
+    return {"status": "deleted"}
+
+
+@app.get(
+    "/portfolios/{portfolio_id}/positions",
+    dependencies=[Depends(require_roles(ALLOWED_ROLES))],
+)
+def aggregated_positions(portfolio_id: int, db: Session = Depends(get_db)) -> List[dict]:
+    """Return aggregated positions for a portfolio grouped by instrument."""
+    exists = db.get(models.Portfolio, portfolio_id)
+    if not exists:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    rows = (
+        db.query(
+            models.Position.instrument,
+            func.sum(models.Position.quantity).label("quantity"),
+        )
+        .filter(models.Position.portfolio_id == portfolio_id)
+        .group_by(models.Position.instrument)
+        .all()
+    )
+    return [{"instrument": r.instrument, "quantity": r.quantity} for r in rows]

--- a/src/portfolio_service/models.py
+++ b/src/portfolio_service/models.py
@@ -1,0 +1,31 @@
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+
+from .db import Base
+
+
+class Portfolio(Base):
+    """Represents an investment portfolio."""
+
+    __tablename__ = "portfolios"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True, nullable=False)
+
+    positions = relationship(
+        "Position", back_populates="portfolio", cascade="all, delete-orphan"
+    )
+
+
+class Position(Base):
+    """Represents an individual holding within a portfolio."""
+
+    __tablename__ = "positions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    portfolio_id = Column(Integer, ForeignKey("portfolios.id"), nullable=False)
+    instrument = Column(String, index=True, nullable=False)
+    quantity = Column(Integer, nullable=False)
+    sector = Column(String, nullable=True)
+
+    portfolio = relationship("Portfolio", back_populates="positions")

--- a/src/portfolio_service/schemas.py
+++ b/src/portfolio_service/schemas.py
@@ -1,0 +1,34 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PositionBase(BaseModel):
+    instrument: str
+    quantity: int
+    sector: Optional[str] = None
+
+
+class PositionCreate(PositionBase):
+    pass
+
+
+class PositionRead(PositionBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PortfolioBase(BaseModel):
+    name: str
+
+
+class PortfolioCreate(PortfolioBase):
+    positions: List[PositionCreate] = []
+
+
+class PortfolioRead(PortfolioBase):
+    id: int
+    positions: List[PositionRead] = []
+
+    model_config = ConfigDict(from_attributes=True)

--- a/tests/test_portfolio_api.py
+++ b/tests/test_portfolio_api.py
@@ -1,0 +1,80 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from portfolio_service.main import app
+from portfolio_service.db import Base, get_db
+
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+Base.metadata.create_all(bind=engine)
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+client = TestClient(app)
+
+
+def test_create_and_aggregate_portfolio():
+    response = client.post(
+        "/portfolios",
+        json={
+            "name": "Alpha",
+            "positions": [
+                {"instrument": "AAPL", "quantity": 50},
+                {"instrument": "AAPL", "quantity": 30},
+            ],
+        },
+        headers={"X-Role": "PM"},
+    )
+    assert response.status_code == 200, response.text
+    portfolio_id = response.json()["id"]
+
+    response = client.get(f"/portfolios/{portfolio_id}", headers={"X-Role": "Client"})
+    assert response.status_code == 200
+
+    response = client.get(
+        f"/portfolios/{portfolio_id}/positions", headers={"X-Role": "Risk"}
+    )
+    assert response.status_code == 200
+    assert response.json() == [{"instrument": "AAPL", "quantity": 80}]
+
+
+def test_create_forbidden_for_client():
+    response = client.post(
+        "/portfolios",
+        json={"name": "Beta", "positions": []},
+        headers={"X-Role": "Client"},
+    )
+    assert response.status_code == 403
+
+
+def test_delete_requires_ops_role():
+    response = client.post(
+        "/portfolios",
+        json={"name": "Gamma", "positions": []},
+        headers={"X-Role": "PM"},
+    )
+    portfolio_id = response.json()["id"]
+
+    response = client.delete(f"/portfolios/{portfolio_id}", headers={"X-Role": "PM"})
+    assert response.status_code == 403
+
+    response = client.delete(f"/portfolios/{portfolio_id}", headers={"X-Role": "Ops"})
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- implement FastAPI portfolio service with ABAC role checks and position aggregation
- add unit tests for portfolio CRUD, access control, and aggregation
- document setup and test commands

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6ed5fe184832489eb15a81b213322