### PR TITLE
Add performance and attribution service

### DIFF
--- a/performance_attribution/README.md
+++ b/performance_attribution/README.md
@@ -1,0 +1,21 @@
+# Performance & Attribution Service
+
+FastAPI service providing portfolio performance metrics and attribution results.
+
+## Endpoints
+
+- `POST /perf/run` – trigger a performance calculation run.
+- `GET /perf/results/{run_id}` – retrieve results for a given run.
+
+## Development
+
+```bash
+pip install -r requirements.txt
+uvicorn performance_attribution.api:create_app --reload
+```
+
+## Testing
+
+```bash
+PYTHONPATH=/workspace/Aegis-IMX pytest performance_attribution/tests
+```

--- a/performance_attribution/__init__.py
+++ b/performance_attribution/__init__.py
@@ -1,0 +1,5 @@
+"""Performance & Attribution service package."""
+
+from .api import create_app
+
+__all__ = ["create_app"]

--- a/performance_attribution/api.py
+++ b/performance_attribution/api.py
@@ -1,0 +1,25 @@
+"""FastAPI app exposing performance endpoints."""
+
+from fastapi import FastAPI, HTTPException
+
+from .models import PerformanceResult, PerformanceRunRequest, PerformanceRunResponse
+from .service import get_run, run_performance
+
+
+def create_app() -> FastAPI:
+    """Application factory."""
+    app = FastAPI(title="Performance & Attribution")
+
+    @app.post("/perf/run", response_model=PerformanceRunResponse)
+    def perf_run(payload: PerformanceRunRequest) -> PerformanceRunResponse:
+        result, run_id = run_performance(payload)
+        return PerformanceRunResponse(run_id=run_id)
+
+    @app.get("/perf/results/{run_id}", response_model=PerformanceResult)
+    def perf_results(run_id: str) -> PerformanceResult:
+        try:
+            return get_run(run_id)
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return app

--- a/performance_attribution/exporters.py
+++ b/performance_attribution/exporters.py
@@ -1,0 +1,39 @@
+"""Result exporters for various formats."""
+
+import csv
+from io import StringIO
+from typing import Iterable, List
+
+from .models import PerformanceResult
+
+try:  # optional dependency
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+except Exception:  # pragma: no cover - pyarrow optional
+    pa = pq = None  # type: ignore
+
+
+def export_csv(results: Iterable[PerformanceResult]) -> str:
+    """Return CSV string for provided results."""
+    items: List[PerformanceResult] = list(results)
+    if not items:
+        return ""
+    buffer = StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=list(items[0].to_dict().keys()))
+    writer.writeheader()
+    for r in items:
+        writer.writerow(r.to_dict())
+    return buffer.getvalue()
+
+
+def export_parquet(results: Iterable[PerformanceResult]) -> bytes:
+    """Return Parquet bytes for provided results."""
+    items = list(results)
+    if not items:
+        return b""
+    if pa is None or pq is None:  # pragma: no cover - optional
+        raise RuntimeError("pyarrow not installed")
+    table = pa.Table.from_pylist([r.to_dict() for r in items])
+    buffer = pa.BufferOutputStream()
+    pq.write_table(table, buffer)
+    return buffer.getvalue().to_pybytes()

--- a/performance_attribution/models.py
+++ b/performance_attribution/models.py
@@ -1,0 +1,60 @@
+"""Pydantic models for Performance & Attribution service."""
+
+from datetime import date
+from typing import List
+
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
+
+
+class PerformanceRunRequest(BaseModel):
+    """Request payload to trigger a performance run."""
+
+    portfolio_id: str = Field(..., description="Unique portfolio identifier")
+    period: str = Field(..., description="ISO period string, e.g. '2023Q1'")
+    returns: List[float] = Field(..., description="Series of periodic returns")
+    cash_flows: List[float] = Field(..., description="Cash flow amounts for IRR")
+    dates: List[date] = Field(..., description="Dates corresponding to returns")
+
+    @field_validator("returns", "cash_flows", "dates")
+    @classmethod
+    def non_empty(cls, v: List) -> List:
+        if not v:
+            raise ValueError("Sequence must not be empty")
+        return v
+
+    @field_validator("dates")
+    @classmethod
+    def returns_date_length(cls, v: List[date], info: ValidationInfo) -> List[date]:
+        returns = info.data.get("returns") if info.data else None
+        if returns is not None and len(v) != len(returns):
+            raise ValueError("dates and returns must be same length")
+        return v
+
+
+class PerformanceRunResponse(BaseModel):
+    """Response after scheduling a performance run."""
+
+    run_id: str = Field(..., description="Server-generated run identifier")
+
+
+class ReturnAttribution(BaseModel):
+    """Simple attribution container."""
+
+    allocation: float
+    selection: float
+    interaction: float
+
+
+class PerformanceResult(BaseModel):
+    """Result payload for completed performance run."""
+
+    portfolio_id: str
+    period: str
+    time_weighted_return: float
+    money_weighted_return: float
+    attribution: ReturnAttribution
+    as_of: date
+
+    def to_dict(self) -> dict:
+        """Return dictionary representation for export convenience."""
+        return self.model_dump()

--- a/performance_attribution/requirements.txt
+++ b/performance_attribution/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.0
+uvicorn==0.30.1
+pydantic==2.7.4
+pyarrow==15.0.0
+pytest==8.1.1
+httpx==0.27.0

--- a/performance_attribution/service.py
+++ b/performance_attribution/service.py
@@ -1,0 +1,70 @@
+"""Business logic for performance calculations."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Dict, Iterable, List
+
+from .models import PerformanceResult, PerformanceRunRequest, ReturnAttribution
+
+logger = logging.getLogger(__name__)
+
+# In-memory run store for demo purposes
+_RUN_STORE: Dict[str, PerformanceResult] = {}
+
+
+def _geometric_link(returns: Iterable[float]) -> float:
+    """Compute geometric linked return (time-weighted)."""
+    result = 1.0
+    for r in returns:
+        result *= 1 + r
+    return result - 1
+
+
+def _irr(cash_flows: List[float]) -> float:
+    """Approximate internal rate of return using Newton-Raphson."""
+    if not any(cf < 0 for cf in cash_flows) or not any(cf > 0 for cf in cash_flows):
+        return 0.0
+    guess = 0.1
+    for _ in range(100):
+        npv = sum(cf / (1 + guess) ** i for i, cf in enumerate(cash_flows))
+        derivative = -sum(i * cf / (1 + guess) ** (i + 1) for i, cf in enumerate(cash_flows))
+        if derivative == 0:
+            break
+        next_guess = guess - npv / derivative
+        if abs(next_guess - guess) < 1e-6:
+            return next_guess
+        guess = next_guess
+    return guess
+
+
+def _brinson_stub() -> ReturnAttribution:
+    """Return neutral attribution placeholder."""
+    return ReturnAttribution(allocation=0.0, selection=0.0, interaction=0.0)
+
+
+def run_performance(request: PerformanceRunRequest) -> PerformanceResult:
+    """Execute performance run and store result in memory."""
+    twr = _geometric_link(request.returns)
+    irr = _irr(request.cash_flows)
+    attribution = _brinson_stub()
+    result = PerformanceResult(
+        portfolio_id=request.portfolio_id,
+        period=request.period,
+        time_weighted_return=twr,
+        money_weighted_return=irr,
+        attribution=attribution,
+        as_of=max(request.dates),
+    )
+    run_id = str(uuid.uuid4())
+    _RUN_STORE[run_id] = result
+    logger.info("Stored performance run %s", run_id)
+    return result, run_id
+
+
+def get_run(run_id: str) -> PerformanceResult:
+    """Retrieve previously computed performance run."""
+    if run_id not in _RUN_STORE:
+        raise KeyError(f"run_id {run_id} not found")
+    return _RUN_STORE[run_id]

--- a/performance_attribution/tests/test_api.py
+++ b/performance_attribution/tests/test_api.py
@@ -1,0 +1,26 @@
+"""API tests using FastAPI TestClient."""
+
+from fastapi.testclient import TestClient
+
+from performance_attribution import create_app
+
+
+client = TestClient(create_app())
+
+
+def test_perf_run_and_results():
+    payload = {
+        "portfolio_id": "P1",
+        "period": "2023Q1",
+        "returns": [0.1, 0.05],
+        "cash_flows": [-100, 60, 60],
+        "dates": ["2023-01-01", "2023-03-31"],
+    }
+    res = client.post("/perf/run", json=payload)
+    assert res.status_code == 200
+    run_id = res.json()["run_id"]
+
+    res2 = client.get(f"/perf/results/{run_id}")
+    assert res2.status_code == 200
+    body = res2.json()
+    assert body["portfolio_id"] == "P1"

--- a/performance_attribution/tests/test_service.py
+++ b/performance_attribution/tests/test_service.py
@@ -1,0 +1,29 @@
+"""Unit tests for performance service."""
+
+from datetime import date
+
+from performance_attribution.models import PerformanceRunRequest
+from performance_attribution.service import _geometric_link, _irr, get_run, run_performance
+
+
+def test_geometric_link():
+    assert abs(_geometric_link([0.1, -0.05]) - 0.045) < 1e-6
+
+
+def test_irr():
+    cf = [-100, 60, 60]
+    irr = _irr(cf)
+    assert 0 < irr < 1
+
+
+def test_run_and_get():
+    req = PerformanceRunRequest(
+        portfolio_id="P1",
+        period="2023Q1",
+        returns=[0.1, 0.05],
+        cash_flows=[-100, 60, 60],
+        dates=[date(2023, 1, 1), date(2023, 3, 31)],
+    )
+    result, run_id = run_performance(req)
+    fetched = get_run(run_id)
+    assert fetched.time_weighted_return == result.time_weighted_return


### PR DESCRIPTION
## Summary
- scaffold Performance & Attribution FastAPI service
- compute time- and money-weighted returns with in-memory run storage
- basic CSV/Parquet exporters and API tests

## Testing
- `PYTHONPATH=/workspace/Aegis-IMX pytest performance_attribution/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a6ee7725208324a0c56c0516997a5c